### PR TITLE
Documentation fixes (and some minor fixes)

### DIFF
--- a/lib/algorithms/binarySearch.js
+++ b/lib/algorithms/binarySearch.js
@@ -3,7 +3,7 @@
  * Returns -1 if the target is not found.
  * @param {number[]} arr
  * @param {number} target
- * @return {number} index The index of the target element within the array.
+ * @return {number} The index of the target element within the array.
  */
 function binarySearch(arr, target) {
   // TODO - Decide which index to return if there are duplicate values in array.

--- a/lib/algorithms/binarySearch.js
+++ b/lib/algorithms/binarySearch.js
@@ -10,7 +10,7 @@ function binarySearch(arr, target) {
   let left = 0;
   let right = arr.length - 1;
   while (left <= right) {
-    const mid = left + Math.floor((right - left) / 2);
+    const mid = Math.floor((right + left) / 2);
     if (arr[mid] === target) {
       return mid;
     }

--- a/lib/algorithms/mergeSort.js
+++ b/lib/algorithms/mergeSort.js
@@ -2,7 +2,7 @@
  * Merges two sorted arrays of elements into one.
  * @param {number[]} arr1
  * @param {number[]} arr2
- * @return {number[]} result A sorted merged array
+ * @return {number[]} A sorted merged array
  */
 function merge(arr1, arr2) {
   const merged = [];

--- a/lib/algorithms/mergeSort.js
+++ b/lib/algorithms/mergeSort.js
@@ -23,14 +23,15 @@ function merge(arr1, arr2) {
 }
 
 /**
- * Sorts an array of elements.
- * @param {number[]} arr
- * @return {number[]} result The sorted array
+ * Sorts an array of elements. Makes a shallow copy of the original array.
+ * @param {number[]} arr The array to be sorted.
+ * @return {number[]} Returns the sorted shallow copy of the original array.
  */
 function mergeSort(arr) {
   if (arr.length < 2) {
     // Arrays of length 0 or 1 are sorted by definition.
-    return arr;
+    // return copy of arr.
+    return arr.slice(0);
   }
 
   const split = Math.floor(arr.length / 2);

--- a/lib/algorithms/quickSort.js
+++ b/lib/algorithms/quickSort.js
@@ -1,9 +1,9 @@
 /**
  * Partitions an array into two parts according to a pivot.
- * @param {number[]} arr
+ * @param {number[]} arr The array to be sorted.
  * @param {number} lo Starting index of the array to partition
  * @param {number} hi Ending index (inclusive) of the array to partition
- * @return {number} pivot
+ * @return {number} Returns the pivot that was chosen.
  */
 function partition(arr, lo, hi) {
   const pivot = arr[hi];
@@ -22,7 +22,7 @@ function partition(arr, lo, hi) {
 
 /**
  * Sorts an array of elements in-place.
- * @param {number[]} arr
+ * @param {number[]} arr The array to be sorted
  * @param {number} lo Starting index of the array to sort
  * @param {number} hi Ending index (inclusive) of the array to sort
  */
@@ -38,8 +38,8 @@ function _quickSort(arr, lo, hi) {
 /**
  * Sorts an array of elements. Makes a shallow copy of the array.
  * Based on Lomuto partition scheme.
- * @param {number[]} arr
- * @return {number[]} result The sorted array
+ * @param {number[]} arr The array to be sorted.
+ * @return {number[]} Returns a sorted shallow copy of the array
  */
 function quickSort(arr) {
   const result = arr.slice(0);

--- a/lib/data-structures/Deque.js
+++ b/lib/data-structures/Deque.js
@@ -3,7 +3,7 @@ import DoublyLinkedList from './DoublyLinkedList';
 class Deque extends DoublyLinkedList {
   /**
    * Adds an element to the back of the Deque.
-   * @param {*} element
+   * @param {*} element The element to be queued to the back of the Deque
    */
   enqueue(element) {
     this.push(element);
@@ -11,7 +11,7 @@ class Deque extends DoublyLinkedList {
 
   /**
    * Adds an element to the front of the Deque.
-   * @param {*} element
+   * @param {*} element The element to be queued to the front of the Deque
    */
   enqueueFront(element) {
     this.unshift(element);
@@ -19,7 +19,7 @@ class Deque extends DoublyLinkedList {
 
   /**
    * Removes the element at the front of the Deque.
-   * @return {*} element The element at the front of the Deque.
+   * @return {*} The element at the front of the Deque.
    */
   dequeue() {
     return this.shift();
@@ -27,7 +27,7 @@ class Deque extends DoublyLinkedList {
 
   /**
    * Removes the element at the back of the Deque.
-   * @return {*} element The element of the back of the Deque.
+   * @return {*} The element of the back of the Deque.
    */
   dequeueBack() {
     return this.pop();

--- a/lib/data-structures/Deque.js
+++ b/lib/data-structures/Deque.js
@@ -3,7 +3,7 @@ import DoublyLinkedList from './DoublyLinkedList';
 class Deque extends DoublyLinkedList {
   /**
    * Adds an element to the back of the Deque.
-   * @param {*} element The element to be queued to the back of the Deque
+   * @param {*} element The element to be queued to the back of the Deque.
    */
   enqueue(element) {
     this.push(element);
@@ -11,7 +11,7 @@ class Deque extends DoublyLinkedList {
 
   /**
    * Adds an element to the front of the Deque.
-   * @param {*} element The element to be queued to the front of the Deque
+   * @param {*} element The element to be queued to the front of the Deque.
    */
   enqueueFront(element) {
     this.unshift(element);
@@ -27,7 +27,7 @@ class Deque extends DoublyLinkedList {
 
   /**
    * Removes the element at the back of the Deque.
-   * @return {*} The element of the back of the Deque.
+   * @return {*} The element at the back of the Deque.
    */
   dequeueBack() {
     return this.pop();

--- a/lib/data-structures/DoublyLinkedList.js
+++ b/lib/data-structures/DoublyLinkedList.js
@@ -12,7 +12,7 @@ class DoublyLinkedList {
   /**
    * Adds an element to the end of the DoublyLinkedList.
    * @param {*} element
-   * @return {number} length The new length of the DoublyLinkedList.
+   * @return {number} The new length of the DoublyLinkedList.
    */
   push(element) {
     const newLastNode = new Node(element); // newLastNode is to be added.
@@ -28,7 +28,7 @@ class DoublyLinkedList {
   /**
    * Adds an element to the front of the DoublyLinkedList.
    * @param {*} element
-   * @return {number} length The new length of the DoublyLinkedList.
+   * @return {number} The new length of the DoublyLinkedList.
    */
   unshift(element) {
     const newFirstNode = new Node(element); // newFirstNode is to be added.
@@ -43,7 +43,7 @@ class DoublyLinkedList {
 
   /**
    * Removes the element at the front of the DoublyLinkedList.
-   * @return {*} element The element at the front of the DoublyLinkedList.
+   * @return {*} The element at the front of the DoublyLinkedList.
    */
   shift() {
     if (this.isEmpty()) {
@@ -61,7 +61,7 @@ class DoublyLinkedList {
 
   /**
    * Removes the element at the back of the DoublyLinkedList.
-   * @return {*} element The element at the back of the DoublyLinkedList.
+   * @return {*} The element at the back of the DoublyLinkedList.
    */
   pop() {
     if (this.isEmpty()) {
@@ -87,7 +87,7 @@ class DoublyLinkedList {
 
   /**
    * Returns the element at the front of the DoublyLinkedList.
-   * @return {*} element The element at the front of the DoublyLinkedList.
+   * @return {*} The element at the front of the DoublyLinkedList.
    */
   front() {
     if (this.isEmpty()) {
@@ -98,7 +98,7 @@ class DoublyLinkedList {
 
   /**
    * Returns the element at the back of the DoublyLinkedList.
-   * @return {*} element The element at the back of the DoublyLinkedList.
+   * @return {*} The element at the back of the DoublyLinkedList.
    */
   back() {
     if (this.isEmpty()) {
@@ -109,7 +109,7 @@ class DoublyLinkedList {
 
   /**
    * Converts the contents of the DoublyLinkedList into an array.
-   * @return {*[]} elements An array of elements.
+   * @return {*[]} An array of elements.
    */
   toArray() {
     const arr = [];
@@ -124,7 +124,7 @@ class DoublyLinkedList {
   /**
    * Creates a DoublyLinkedList instance from an array of elements.
    * @param {*[]} arr
-   * @return {DoublyLinkedList} doublyLinkedList A new DoublyLinkList instance containing the element.
+   * @return {DoublyLinkedList} A new DoublyLinkList instance containing the element.
    */
   static fromArray(arr) {
     const dll = new DoublyLinkedList();
@@ -137,7 +137,7 @@ class DoublyLinkedList {
    * After calling this method, the DoublyLinkedList instance will be cleared
    * out and should not be used anymore.
    * Intended for users who want to manage their own nodes directly without a wrapper class.
-   * @return {Node} node The internal head Node.
+   * @return {Node} The internal head Node.
    */
   headNode() {
     if (this.isEmpty()) {

--- a/lib/data-structures/Queue.js
+++ b/lib/data-structures/Queue.js
@@ -10,7 +10,7 @@ class Queue {
   /**
    * Adds an element to the back of the Queue.
    * @param {*} element
-   * @param {number} length The new length of the Queue.
+   * @return {number} The new length of the Queue.
    */
   enqueue(value) {
     const node = new Node(value);

--- a/lib/data-structures/Queue.js
+++ b/lib/data-structures/Queue.js
@@ -22,7 +22,7 @@ class Queue {
 
   /**
    * Removes the element at the front of the Queue.
-   * @return {*} element The element at the front of the Queue.
+   * @return {*} The element at the front of the Queue.
    */
   dequeue() {
     if (this.isEmpty()) {
@@ -37,7 +37,7 @@ class Queue {
 
   /**
    * Returns true if the Queue has no elements.
-   * @return {boolean} empty Whether the Queue has no elements.
+   * @return {boolean} Whether the Queue has no elements.
    */
   isEmpty() {
     return this.length === 0;
@@ -45,7 +45,7 @@ class Queue {
 
   /**
    * Returns the element at the front of the Queue.
-   * @return {*} element The element at the front of the Queue.
+   * @return {*} The element at the front of the Queue.
    */
   front() {
     if (this.isEmpty()) {
@@ -56,7 +56,7 @@ class Queue {
 
   /**
    * Returns the element at the back of the Queue.
-   * @return {*} element The element at the back of the Queue.
+   * @return {*} The element at the back of the Queue.
    */
   back() {
     if (this.isEmpty()) {

--- a/lib/data-structures/Stack.js
+++ b/lib/data-structures/Stack.js
@@ -9,7 +9,7 @@ class Stack {
   /**
    * Adds an element to the top of the Stack.
    * @param {*} element
-   * @return {number} length The new length of the Stack.
+   * @return {number} The new length of the Stack.
    */
   push(value) {
     const node = new Node(value);
@@ -21,7 +21,7 @@ class Stack {
 
   /**
    * Removes the element at the top of the Stack.
-   * @return {number} length The new length of the Stack.
+   * @return {number} The new length of the Stack.
    */
   pop() {
     if (this.isEmpty()) {
@@ -36,7 +36,7 @@ class Stack {
 
   /**
    * Returns true if the Stack has no elements.
-   * @return {boolean} empty Whether the Stack has no elements.
+   * @return {boolean} Whether the Stack has no elements.
    */
   isEmpty() {
     return this.length === 0;
@@ -44,7 +44,7 @@ class Stack {
 
   /**
    * Returns the element at the top of the Stack.
-   * @return {*} element The element at the top of the Stack.
+   * @return {*} The element at the top of the Stack.
    */
   peek() {
     if (this.isEmpty()) {

--- a/lib/data-structures/Trie.js
+++ b/lib/data-structures/Trie.js
@@ -66,7 +66,7 @@ class Trie {
   /**
    * Deletes a string from the Trie.
    * @param {string} string
-   * @return {boolean} success Whether the deletion was successful.
+   * @return {boolean} Whether the deletion was successful.
    */
   delete(string) {
     if (!string) {
@@ -103,7 +103,7 @@ class Trie {
   /**
    * Counts the number of times a string appears in the Trie.
    * @param {string} string
-   * @return {boolean} count The number of times a string appears in the Trie.
+   * @return {boolean} The number of times a string appears in the Trie.
    */
   count(string) {
     if (!string) {
@@ -123,7 +123,7 @@ class Trie {
   /**
    * Determine if a string is in the Trie.
    * @param {string} string
-   * @return {boolean} result Whether the string is in the Trie.
+   * @return {boolean} Whether the string is in the Trie.
    */
   contains(string) {
     return this.count(string) !== 0;
@@ -165,7 +165,7 @@ class Trie {
    * Counts the total number of strings in the Trie
    * that start with the given prefix.
    * @param {string} prefix
-   * @return {number} count The total number of strings in the Trie that start with the prefix.
+   * @return {number} The total number of strings in the Trie that start with the prefix.
    */
   countStringsStartingWith(prefix) {
     const results = this.stringsStartingWith(prefix);
@@ -179,7 +179,7 @@ class Trie {
    * Counts the different number of strings in the Trie
    * that start with the given prefix.
    * @param {string} prefix
-   * @return {number} count The different number of strings in the Trie that start with the prefix.
+   * @return {number} The different number of strings in the Trie that start with the prefix.
    */
   differentStringsStartingWith(prefix) {
     const results = this.stringsStartingWith(prefix);


### PR DESCRIPTION
- Mostly removing the "variable name" from the return tags in jsdocs comments. 
- one fix for binary search by removing one term when calculating for the `mid`.
- fix consistency of `mergeSort`. When `arr.length < 2`, the original array is returned, whereas the otherwise a shallow copy is returned. so I made it such that a shallow copy is returned when `arr.length < 2`. 