### PR TITLE
feat: AVL Implementation of BinarySearchTree

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,12 @@
+{
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Tests",
+      "program": "${workspaceRoot}/node_modules/tsdx/dist/index.js",
+      "args": ["test", "--runInBand"],
+      "internalConsoleOptions": "openOnSessionStart"
+    }
+  ]
+}

--- a/src/data-structures/AvlTree.ts
+++ b/src/data-structures/AvlTree.ts
@@ -1,0 +1,77 @@
+import BinaryTreeNode from './BinaryTreeNode';
+import BinarySearchTree from './BinarySearchTree';
+
+/**
+ * An implementation of AvlTree based on BinarySearchTrees
+ */
+class AvlTree extends BinarySearchTree {
+  protected _insertImpl(
+    value: number,
+    node: BinaryTreeNode<number> | null,
+  ): BinaryTreeNode<number> {
+    return this._balance(super._insertImpl(value, node));
+  }
+
+  protected _deleteImpl = (
+    value: number,
+    node: BinaryTreeNode<number> | null,
+  ): BinaryTreeNode<number> | null => {
+    node = super._insertImpl(value, node);
+    return node ? this._balance(node!) : node;
+  };
+
+  _balance(node: BinaryTreeNode<number>): BinaryTreeNode<number> {
+    // Helper function to calculate the balance of the node
+    const calcBalance = (node: BinaryTreeNode<number>): number =>
+      (node.left?.height() || 0) - (node.right?.height() || 0) + 1;
+
+    // Check for whether the node is out-of-balance
+    const balance = calcBalance(node);
+
+    if (balance > 1) {
+      const leftBalance = calcBalance(node.left!);
+      if (leftBalance < 0) {
+        // LL case
+        node = this._rotateRight(node);
+      } else {
+        // LR case
+        node.left = this._rotateLeft(node.left!);
+        node = this._rotateRight(node);
+      }
+    } else if (balance < -1) {
+      const rightBalance = calcBalance(node.right!);
+      if (rightBalance < 0) {
+        // RL case
+        node.right = this._rotateRight(node.right!);
+        node = this._rotateLeft(node);
+      } else {
+        // RR case
+        node = this._rotateLeft(node);
+      }
+    }
+
+    return node;
+  }
+
+  _rotateRight(node: BinaryTreeNode<number>): BinaryTreeNode<number> {
+    const { left } = node;
+    const { right } = left!;
+
+    left!.right = node;
+    node.left = right;
+
+    return left!;
+  }
+
+  _rotateLeft(node: BinaryTreeNode<number>): BinaryTreeNode<number> {
+    const { right } = node;
+    const { left } = right!;
+
+    right!.left = node;
+    node.right = left;
+
+    return right!;
+  }
+}
+
+export default AvlTree;

--- a/src/data-structures/AvlTree.ts
+++ b/src/data-structures/AvlTree.ts
@@ -16,35 +16,36 @@ class AvlTree extends BinarySearchTree {
     value: number,
     node: BinaryTreeNode<number> | null,
   ): BinaryTreeNode<number> | null => {
-    node = super._insertImpl(value, node);
+    node = super._deleteImpl(value, node);
     return node ? this._balance(node!) : node;
   };
 
   _balance(node: BinaryTreeNode<number>): BinaryTreeNode<number> {
     // Helper function to calculate the balance of the node
     const calcBalance = (node: BinaryTreeNode<number>): number =>
-      (node.left?.height() || 0) - (node.right?.height() || 0) + 1;
+      (node.left ? node.left!.height() + 1 : 0) -
+      (node.right ? node.right?.height() + 1 : 0);
 
     // Check for whether the node is out-of-balance
     const balance = calcBalance(node);
 
     if (balance > 1) {
       const leftBalance = calcBalance(node.left!);
-      if (leftBalance < 0) {
+      if (leftBalance > 0) {
         // LL case
         node = this._rotateRight(node);
-      } else {
+      } else if (leftBalance < 0) {
         // LR case
         node.left = this._rotateLeft(node.left!);
         node = this._rotateRight(node);
       }
     } else if (balance < -1) {
       const rightBalance = calcBalance(node.right!);
-      if (rightBalance < 0) {
+      if (rightBalance > 0) {
         // RL case
         node.right = this._rotateRight(node.right!);
         node = this._rotateLeft(node);
-      } else {
+      } else if (rightBalance < 0) {
         // RR case
         node = this._rotateLeft(node);
       }

--- a/src/data-structures/BinarySearchTree.ts
+++ b/src/data-structures/BinarySearchTree.ts
@@ -5,39 +5,9 @@ class BinarySearchTree extends BinaryTree<number> {
   /**
    * Recursively insert a new value in the BST.
    * @param {number} value The value being inserted
-   * @param {BinaryTreeNode} node The current node. Param is not required.
-   * @return {void}
    */
   insert(val: number): void {
-    if (!this.root) {
-      this.root = new BinaryTreeNode(val);
-      return;
-    }
-
-    function insertImpl(value: number, node: BinaryTreeNode<number>) {
-      const nodeValue = node.value;
-
-      if (value < nodeValue) {
-        const { left } = node;
-        if (!left) {
-          node.left = new BinaryTreeNode(value);
-          return;
-        }
-
-        insertImpl(value, left);
-        return;
-      }
-
-      const { right } = node;
-      if (!right) {
-        node.right = new BinaryTreeNode(value);
-        return;
-      }
-
-      insertImpl(value, right);
-    }
-
-    insertImpl(val, this.root);
+    this.root = this._insertImpl(val, this.root);
   }
 
   /**
@@ -69,6 +39,25 @@ class BinarySearchTree extends BinaryTree<number> {
     }
 
     return searchImpl(val, this.root);
+  }
+
+  protected _insertImpl(
+    value: number,
+    node: BinaryTreeNode<number> | null,
+  ): BinaryTreeNode<number> {
+    if (!node) {
+      return new BinaryTreeNode(value);
+    }
+
+    // Normal BST insert
+    // NOTE: Duplicates are sent to the left
+    if (value <= node.value) {
+      node.left = this._insertImpl(value, node.left);
+    } else {
+      node.right = this._insertImpl(value, node.right);
+    }
+
+    return node;
   }
 
   private _getMinimumNode(
@@ -126,49 +115,49 @@ class BinarySearchTree extends BinaryTree<number> {
    * @return {BinaryTreeNode} The root node after deletion.
    */
   delete(val: number): BinaryTreeNode<number> | null {
-    const deleteImpl = (
-      value: number,
-      node: BinaryTreeNode<number> | null,
-    ): BinaryTreeNode<number> | null => {
-      if (!node) {
-        return null;
-      }
-
-      const nodeValue = node.value;
-      const { left } = node;
-      const { right } = node;
-      if (value < nodeValue) {
-        node.left = deleteImpl(value, left);
-        return node;
-      } else if (value > nodeValue) {
-        node.right = deleteImpl(value, right);
-        return node;
-      }
-
-      if (!left && !right) {
-        return null;
-      }
-
-      if (!left) {
-        return right;
-      }
-
-      if (!right) {
-        return left;
-      }
-
-      const tempNode: BinaryTreeNode<number> = this._getMinimumNode(
-        right,
-      ) as BinaryTreeNode<number>;
-      node.value = tempNode.value;
-      node.right = deleteImpl(tempNode.value, right);
-
-      return node;
-    };
-
-    this.root = deleteImpl(val, this.root);
+    this.root = this._deleteImpl(val, this.root);
     return this.root;
   }
+
+  protected _deleteImpl = (
+    value: number,
+    node: BinaryTreeNode<number> | null,
+  ): BinaryTreeNode<number> | null => {
+    if (!node) {
+      return null;
+    }
+
+    const nodeValue = node.value;
+    const { left } = node;
+    const { right } = node;
+    if (value < nodeValue) {
+      node.left = this._deleteImpl(value, left);
+      return node;
+    } else if (value > nodeValue) {
+      node.right = this._deleteImpl(value, right);
+      return node;
+    }
+
+    if (!left && !right) {
+      return null;
+    }
+
+    if (!left) {
+      return right;
+    }
+
+    if (!right) {
+      return left;
+    }
+
+    const tempNode: BinaryTreeNode<number> = this._getMinimumNode(
+      right,
+    ) as BinaryTreeNode<number>;
+    node.value = tempNode.value;
+    node.right = this._deleteImpl(tempNode.value, right);
+
+    return node;
+  };
 }
 
 export default BinarySearchTree;

--- a/src/data-structures/BinarySearchTree.ts
+++ b/src/data-structures/BinarySearchTree.ts
@@ -119,10 +119,10 @@ class BinarySearchTree extends BinaryTree<number> {
     return this.root;
   }
 
-  protected _deleteImpl = (
+  protected _deleteImpl(
     value: number,
     node: BinaryTreeNode<number> | null,
-  ): BinaryTreeNode<number> | null => {
+  ): BinaryTreeNode<number> | null {
     if (!node) {
       return null;
     }
@@ -157,7 +157,7 @@ class BinarySearchTree extends BinaryTree<number> {
     node.right = this._deleteImpl(tempNode.value, right);
 
     return node;
-  };
+  }
 }
 
 export default BinarySearchTree;

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,6 +14,7 @@ import topologicalSort from './algorithms/topologicalSort';
 
 // Data Structures
 import BinarySearchTree from './data-structures/BinarySearchTree';
+import AvlTree from './data-structures/AvlTree';
 import BinaryTree from './data-structures/BinaryTree';
 import BinaryTreeNode from './data-structures/BinaryTreeNode';
 import BloomFilter from './data-structures/BloomFilter';
@@ -51,6 +52,7 @@ export {
   topologicalSort,
   // Data Structures
   BinarySearchTree,
+  AvlTree,
   BinaryTree,
   BinaryTreeNode,
   BloomFilter,

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,8 +13,8 @@ import quickSort from './algorithms/quickSort';
 import topologicalSort from './algorithms/topologicalSort';
 
 // Data Structures
-import BinarySearchTree from './data-structures/BinarySearchTree';
 import AvlTree from './data-structures/AvlTree';
+import BinarySearchTree from './data-structures/BinarySearchTree';
 import BinaryTree from './data-structures/BinaryTree';
 import BinaryTreeNode from './data-structures/BinaryTreeNode';
 import BloomFilter from './data-structures/BloomFilter';
@@ -51,8 +51,8 @@ export {
   quickSort,
   topologicalSort,
   // Data Structures
-  BinarySearchTree,
   AvlTree,
+  BinarySearchTree,
   BinaryTree,
   BinaryTreeNode,
   BloomFilter,

--- a/test/data-structures/AvlTree.test.ts
+++ b/test/data-structures/AvlTree.test.ts
@@ -1,200 +1,137 @@
-import { AvlTree } from '../../src';
-import nullthrows from '../../src/utils/nullthrows';
+import _ from 'lodash';
+import { AvlTree, BinaryTreeNode } from '../../src';
+
+import { binarySearchTreeTests } from './BinarySearchTree.test';
 
 describe('AvtTree', () => {
-  describe('insert()', () => {
-    test('if empty tree, value becomes root', () => {
+  describe('normal binary test', () => {
+    // Test against normal BST test cases
+    binarySearchTreeTests(describe, test);
+  });
+
+  describe('self-balancing', () => {
+    describe('insert', () => {
+      test('LL rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(10);
+        tree.insert(9);
+        tree.insert(8);
+        expect(tree.height()).toBe(1);
+
+        tree.insert(11);
+        expect(tree.height()).toBe(2);
+      });
+
+      test('LR rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(10);
+        tree.insert(8);
+        tree.insert(9);
+        expect(tree.height()).toBe(1);
+
+        tree.insert(11);
+        expect(tree.height()).toBe(2);
+      });
+
+      test('RR rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(8);
+        tree.insert(9);
+        tree.insert(10);
+        expect(tree.height()).toBe(1);
+
+        tree.insert(11);
+        expect(tree.height()).toBe(2);
+      });
+
+      test('RL rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(8);
+        tree.insert(10);
+        tree.insert(9);
+        expect(tree.height()).toBe(1);
+
+        tree.insert(11);
+        expect(tree.height()).toBe(2);
+      });
+    });
+
+    describe('delete', () => {
+      test('LL rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(5);
+        tree.insert(3);
+        tree.insert(8);
+        tree.insert(4);
+        tree.insert(2);
+        tree.insert(10);
+        tree.insert(1);
+        expect(tree.height()).toBe(3);
+
+        tree.delete(10);
+        expect(tree.height()).toBe(2);
+      });
+
+      test('LR rotation', () => {
+        const tree = new AvlTree();
+        tree.insert(100);
+        tree.insert(200);
+        tree.insert(10);
+        tree.insert(1);
+        tree.insert(50);
+        tree.insert(1000);
+        tree.insert(40);
+        tree.insert(60);
+        expect(tree.height()).toBe(3);
+
+        tree.delete(1000);
+        expect(tree.height()).toBe(2);
+      });
+    });
+
+    describe('duplicate', () => {
+      test.skip('test for duplicates in AVL', () => {
+        expect(true).toBe(true);
+      });
+    });
+
+    test.skip('random stress test', () => {
+      const assertAvl = (node: BinaryTreeNode<number> | null) => {
+        if (!node) return;
+
+        // assert BST property
+        if (node.left)
+          expect(node.value).toBeGreaterThanOrEqual(node.left.value);
+        if (node.right) expect(node.value).toBeLessThan(node.right.value);
+
+        // assert balancing property
+        const balance =
+          (node.left ? node.left!.height() + 1 : 0) -
+          (node.right ? node.right?.height() + 1 : 0);
+        expect(Math.abs(balance)).toBeLessThanOrEqual(1);
+
+        assertAvl(node.left);
+        assertAvl(node.right);
+      };
+
       const tree = new AvlTree();
-      tree.insert(5);
-      expect(nullthrows(tree.root).value).toBe(5);
-    });
 
-    test('inserts value at correct location in BST', () => {
-      const tree = new AvlTree(30);
-      tree.insert(20);
-      tree.insert(40);
-      tree.insert(35);
+      // Build a tree of 100 random numbers, assert the tree is AVL tree
+      _.times(100, () => {
+        tree.insert(Math.floor(Math.random() * 50));
 
-      const root = nullthrows(tree.root);
-      expect(nullthrows(root.left).value).toBe(20);
-      expect(nullthrows(root.right).value).toBe(40);
-    });
-  });
+        assertAvl(tree.root);
+      });
 
-  describe('search()', () => {
-    test('returns correct result based on value', () => {
-      const tree = new AvlTree(30);
-      tree.insert(20);
-      tree.insert(40);
-      tree.insert(25);
-      tree.insert(50);
-      tree.insert(35);
+      // Delete off 50 random numbers, assert the tree is AVL the whole time
+      const arr = tree.inOrder();
+      _.times(50, () => {
+        const index = Math.floor(Math.random() * arr.length);
+        tree.delete(arr[index]);
+        arr.splice(index, 1);
 
-      let searchResult = tree.search(35);
-      expect(searchResult).toBe(true);
-      searchResult = tree.search(555);
-      expect(searchResult).toBe(false);
-    });
-  });
-
-  describe('getMinimum()', () => {
-    test('empty tree', () => {
-      const tree = new AvlTree();
-      expect(tree.getMinimum()).toBe(null);
-    });
-
-    test.only('non-empty tree', () => {
-      const tree = new AvlTree(10);
-      tree.insert(5);
-      tree.insert(15);
-      tree.insert(2);
-      expect(tree.getMinimum()).toBe(2);
-    });
-  });
-
-  describe('getMaximum()', () => {
-    test('empty tree', () => {
-      const tree = new AvlTree();
-      expect(tree.getMaximum()).toBe(null);
-    });
-
-    test('non-empty tree', () => {
-      const tree = new AvlTree(10);
-      tree.insert(5);
-      tree.insert(15);
-      tree.insert(2);
-      expect(tree.getMaximum()).toBe(15);
-    });
-  });
-
-  describe('delete()', () => {
-    test('delete node from single-node BST', () => {
-      const tree = new AvlTree(20);
-      tree.delete(20);
-      expect(tree.inOrder()).toEqual([]);
-    });
-
-    test('delete root node from BST', () => {
-      const tree = new AvlTree(30);
-      tree.insert(20);
-      tree.insert(40);
-      tree.insert(10);
-      tree.insert(50);
-      tree.insert(5);
-      tree.insert(6);
-      tree.delete(30);
-      expect(tree.inOrder()).toEqual([5, 6, 10, 20, 40, 50]);
-    });
-
-    test('delete value from BST which does not exists', () => {
-      const tree = new AvlTree(20);
-      tree.insert(10);
-      tree.insert(50);
-      tree.insert(60);
-      tree.insert(40);
-      tree.insert(70);
-      tree.insert(5);
-      tree.insert(6);
-      tree.delete(100);
-      expect(tree.inOrder()).toEqual([5, 6, 10, 20, 40, 50, 60, 70]);
-    });
-
-    test('deletes value from the BST', () => {
-      const tree = new AvlTree(50);
-      tree.insert(20);
-      tree.insert(10);
-      tree.insert(5);
-      tree.insert(15);
-      tree.insert(12);
-      tree.insert(14);
-      tree.insert(30);
-      tree.insert(35);
-      tree.insert(40);
-      tree.insert(60);
-      tree.insert(55);
-      tree.insert(80);
-      tree.insert(70);
-      tree.insert(100);
-      tree.delete(100);
-      expect(tree.inOrder()).toEqual([
-        5,
-        10,
-        12,
-        14,
-        15,
-        20,
-        30,
-        35,
-        40,
-        50,
-        55,
-        60,
-        70,
-        80,
-      ]);
-
-      tree.delete(10);
-      expect(tree.inOrder()).toEqual([
-        5,
-        12,
-        14,
-        15,
-        20,
-        30,
-        35,
-        40,
-        50,
-        55,
-        60,
-        70,
-        80,
-      ]);
-
-      tree.delete(80);
-      expect(tree.inOrder()).toEqual([
-        5,
-        12,
-        14,
-        15,
-        20,
-        30,
-        35,
-        40,
-        50,
-        55,
-        60,
-        70,
-      ]);
-
-      tree.delete(20);
-      expect(tree.inOrder()).toEqual([
-        5,
-        12,
-        14,
-        15,
-        30,
-        35,
-        40,
-        50,
-        55,
-        60,
-        70,
-      ]);
-
-      tree.delete(15);
-      tree.delete(60);
-      expect(tree.inOrder()).toEqual([5, 12, 14, 30, 35, 40, 50, 55, 70]);
-
-      tree.delete(35);
-      tree.delete(12);
-      expect(tree.inOrder()).toEqual([5, 14, 30, 40, 50, 55, 70]);
-
-      tree.delete(30);
-      expect(tree.inOrder()).toEqual([5, 14, 40, 50, 55, 70]);
-
-      tree.delete(40);
-      tree.delete(50);
-      expect(tree.inOrder()).toEqual([5, 14, 55, 70]);
+        assertAvl(tree.root);
+      });
     });
   });
 });

--- a/test/data-structures/AvlTree.test.ts
+++ b/test/data-structures/AvlTree.test.ts
@@ -1,0 +1,200 @@
+import { AvlTree } from '../../src';
+import nullthrows from '../../src/utils/nullthrows';
+
+describe('AvtTree', () => {
+  describe('insert()', () => {
+    test('if empty tree, value becomes root', () => {
+      const tree = new AvlTree();
+      tree.insert(5);
+      expect(nullthrows(tree.root).value).toBe(5);
+    });
+
+    test('inserts value at correct location in BST', () => {
+      const tree = new AvlTree(30);
+      tree.insert(20);
+      tree.insert(40);
+      tree.insert(35);
+
+      const root = nullthrows(tree.root);
+      expect(nullthrows(root.left).value).toBe(20);
+      expect(nullthrows(root.right).value).toBe(40);
+    });
+  });
+
+  describe('search()', () => {
+    test('returns correct result based on value', () => {
+      const tree = new AvlTree(30);
+      tree.insert(20);
+      tree.insert(40);
+      tree.insert(25);
+      tree.insert(50);
+      tree.insert(35);
+
+      let searchResult = tree.search(35);
+      expect(searchResult).toBe(true);
+      searchResult = tree.search(555);
+      expect(searchResult).toBe(false);
+    });
+  });
+
+  describe('getMinimum()', () => {
+    test('empty tree', () => {
+      const tree = new AvlTree();
+      expect(tree.getMinimum()).toBe(null);
+    });
+
+    test.only('non-empty tree', () => {
+      const tree = new AvlTree(10);
+      tree.insert(5);
+      tree.insert(15);
+      tree.insert(2);
+      expect(tree.getMinimum()).toBe(2);
+    });
+  });
+
+  describe('getMaximum()', () => {
+    test('empty tree', () => {
+      const tree = new AvlTree();
+      expect(tree.getMaximum()).toBe(null);
+    });
+
+    test('non-empty tree', () => {
+      const tree = new AvlTree(10);
+      tree.insert(5);
+      tree.insert(15);
+      tree.insert(2);
+      expect(tree.getMaximum()).toBe(15);
+    });
+  });
+
+  describe('delete()', () => {
+    test('delete node from single-node BST', () => {
+      const tree = new AvlTree(20);
+      tree.delete(20);
+      expect(tree.inOrder()).toEqual([]);
+    });
+
+    test('delete root node from BST', () => {
+      const tree = new AvlTree(30);
+      tree.insert(20);
+      tree.insert(40);
+      tree.insert(10);
+      tree.insert(50);
+      tree.insert(5);
+      tree.insert(6);
+      tree.delete(30);
+      expect(tree.inOrder()).toEqual([5, 6, 10, 20, 40, 50]);
+    });
+
+    test('delete value from BST which does not exists', () => {
+      const tree = new AvlTree(20);
+      tree.insert(10);
+      tree.insert(50);
+      tree.insert(60);
+      tree.insert(40);
+      tree.insert(70);
+      tree.insert(5);
+      tree.insert(6);
+      tree.delete(100);
+      expect(tree.inOrder()).toEqual([5, 6, 10, 20, 40, 50, 60, 70]);
+    });
+
+    test('deletes value from the BST', () => {
+      const tree = new AvlTree(50);
+      tree.insert(20);
+      tree.insert(10);
+      tree.insert(5);
+      tree.insert(15);
+      tree.insert(12);
+      tree.insert(14);
+      tree.insert(30);
+      tree.insert(35);
+      tree.insert(40);
+      tree.insert(60);
+      tree.insert(55);
+      tree.insert(80);
+      tree.insert(70);
+      tree.insert(100);
+      tree.delete(100);
+      expect(tree.inOrder()).toEqual([
+        5,
+        10,
+        12,
+        14,
+        15,
+        20,
+        30,
+        35,
+        40,
+        50,
+        55,
+        60,
+        70,
+        80,
+      ]);
+
+      tree.delete(10);
+      expect(tree.inOrder()).toEqual([
+        5,
+        12,
+        14,
+        15,
+        20,
+        30,
+        35,
+        40,
+        50,
+        55,
+        60,
+        70,
+        80,
+      ]);
+
+      tree.delete(80);
+      expect(tree.inOrder()).toEqual([
+        5,
+        12,
+        14,
+        15,
+        20,
+        30,
+        35,
+        40,
+        50,
+        55,
+        60,
+        70,
+      ]);
+
+      tree.delete(20);
+      expect(tree.inOrder()).toEqual([
+        5,
+        12,
+        14,
+        15,
+        30,
+        35,
+        40,
+        50,
+        55,
+        60,
+        70,
+      ]);
+
+      tree.delete(15);
+      tree.delete(60);
+      expect(tree.inOrder()).toEqual([5, 12, 14, 30, 35, 40, 50, 55, 70]);
+
+      tree.delete(35);
+      tree.delete(12);
+      expect(tree.inOrder()).toEqual([5, 14, 30, 40, 50, 55, 70]);
+
+      tree.delete(30);
+      expect(tree.inOrder()).toEqual([5, 14, 40, 50, 55, 70]);
+
+      tree.delete(40);
+      tree.delete(50);
+      expect(tree.inOrder()).toEqual([5, 14, 55, 70]);
+    });
+  });
+});

--- a/test/data-structures/BinarySearchTree.test.ts
+++ b/test/data-structures/BinarySearchTree.test.ts
@@ -1,7 +1,12 @@
 import { BinarySearchTree } from '../../src';
 import nullthrows from '../../src/utils/nullthrows';
 
-describe('BinarySearchTree', () => {
+export const binarySearchTreeTests = (
+  /* eslint-disable @typescript-eslint/no-explicit-any */
+  describe: any,
+  test: any,
+  /* eslint-enable @typescript-eslint/no-explicit-any */
+) => {
   describe('insert()', () => {
     test('if empty tree, value becomes root', () => {
       const tree = new BinarySearchTree();
@@ -197,4 +202,8 @@ describe('BinarySearchTree', () => {
       expect(tree.inOrder()).toEqual([5, 14, 55, 70]);
     });
   });
+};
+
+describe('BinarySearchTree', () => {
+  binarySearchTreeTests(describe, test);
 });


### PR DESCRIPTION
### Description:
Written a simple AVL Tree extending BinarySearchTree. Expose BST `insertImpl` and `deleteImpl` for a more elegant AVL extension :)

Essentially:
```Js
_insertImpl(value, node) {
    node = super._insertImpl(value, node);
    return this._balance(node);
}

_deleteImpl(value, node) {
    node = super._deleteImpl(value, node);
    return this._balance(node);
}
```

### Type of change:
New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
Tested against the test cases for BST.
Added extra test cases for AVL rotations to check for correctness.

### Current problem:
This AVL implementations should work flawlessly for tree with unique elements, but would not ensure correctness when we have duplicate elements (due to rotations, check the [skipped tests](https://github.com/ngtrhieu/lago/blob/256d9dae898a9f0c73d21fffa764c1fdff6aa05d/test/data-structures/AvlTree.test.ts#L98)).

I kinda think of 3 ways to deal with it:
- Make AVL implementation separate from BST -- useful if you want to reference how to write AVL from scratch :), but lose the elegant-ness of having an AVL extension.
- Change BST implementation such as a BST node keep track of how many duplicates it have. the BST definition can use strict lesser/greater.
- Change BST implementation to use a _'comparer/comparator'_. AVL can then "mod" the _comparer_ to for tiebreak, essentially eliminate duplicates.

Your choice on how you want to deal with this :)

### Related Issues
#5 